### PR TITLE
Cards layout tweaks and sidebar fixes

### DIFF
--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -78,6 +78,37 @@ label {
   padding-top: 1rem;
 }
 
+/* Sidebar toggle: show a subtle strip when collapsed */
+#observablehq-sidebar-toggle {
+  background: var(--theme-background-alt);
+  opacity: 0.6;
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
+  transition: opacity 150ms ease;
+}
+#observablehq-sidebar-toggle:hover {
+  opacity: 1;
+}
+#observablehq-sidebar-toggle:checked {
+  background: none;
+  border-right: none;
+  opacity: 1;
+}
+
+/* Close button: position:fixed to escape the position:sticky <ol> containing block */
+#observablehq-sidebar-close {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  left: calc(272px + var(--observablehq-sidebar-padding-left) - 2rem);
+  right: auto;
+  height: 2rem;
+  visibility: hidden;
+}
+#observablehq-sidebar-toggle:checked ~ #observablehq-sidebar #observablehq-sidebar-close,
+#observablehq-sidebar-toggle:indeterminate ~ #observablehq-sidebar #observablehq-sidebar-close {
+  visibility: visible;
+}
+
 #observablehq-main,
 #observablehq-header,
 #observablehq-footer {

--- a/src/eina.css
+++ b/src/eina.css
@@ -52,6 +52,46 @@ main h2 {
 
 /* Observable layout overrides */
 
+/* Sidebar toggle: show a subtle strip when collapsed */
+#observablehq-sidebar-toggle {
+  background: var(--theme-background-alt);
+  opacity: 0.6;
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
+  transition: opacity 150ms ease;
+}
+#observablehq-sidebar-toggle:hover {
+  opacity: 1;
+}
+#observablehq-sidebar-toggle:checked {
+  background: none;
+  border-right: none;
+  opacity: 1;
+}
+
+/* Pin sidebar to 200px — matches the --observablehq-inset-left: calc(200px + 1rem)
+   override below. Without this the width falls to auto (the framework's calc is
+   invalid because --observablehq-max-width: none), causing unpredictable layout. */
+#observablehq-sidebar {
+  width: 200px;
+}
+
+/* Close button: position:fixed to escape the position:sticky <ol> containing block,
+   then centre it in the sidebar. left = sidebar-width − button-width. */
+#observablehq-sidebar-close {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  left: calc(200px - 2rem);
+  right: auto;
+  height: 2rem;
+  visibility: hidden; /* position:fixed escapes the sidebar's visibility:hidden */
+}
+/* Reveal only while the sidebar is actually open */
+#observablehq-sidebar-toggle:checked ~ #observablehq-sidebar #observablehq-sidebar-close,
+#observablehq-sidebar-toggle:indeterminate ~ #observablehq-sidebar #observablehq-sidebar-close {
+  visibility: visible;
+}
+
 #observablehq-center {
   margin: 2rem 2rem 2rem;
   overflow: visible;
@@ -227,9 +267,9 @@ label {
 @media (min-width: calc(912px + 6rem)) {
   #observablehq-sidebar-toggle:checked ~ #observablehq-center,
   #observablehq-sidebar-toggle:indeterminate ~ #observablehq-center {
-    --observablehq-inset-left: calc(200px + 1rem); /* adjust as needed */
+    --observablehq-inset-left: calc(200px + 1rem);
     padding-left: var(--observablehq-inset-left);
-    /* padding-right stays as default 1rem */
+    margin-left: 0; /* cancel the base 2rem so the gap from sidebar is just 1rem */
   }
 }
 
@@ -240,7 +280,8 @@ label {
   position: fixed;
   z-index: 10;
   pointer-events: none;
-  width: 240px;
+  width: max-content;
+  max-width: 340px;
   padding: 10px 12px;
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.4);
@@ -270,6 +311,7 @@ label {
 }
 .mb-tip-row span:last-child {
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 /* ========================================
@@ -444,6 +486,7 @@ label {
   width: auto;
   max-width: calc(100vw - 2rem);
   pointer-events: auto;
+  margin-bottom: 2rem;
 }
 
 @media (min-width: 800px) {
@@ -541,7 +584,39 @@ label {
 
 .cluster-modal-ref {
   font-family: var(--mono, monospace);
+  font-size: inherit;
   color: var(--glassText);
+  background: none;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.cluster-modal-ref:hover {
+  text-decoration-thickness: 2px;
+}
+
+.copy-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  translate: -50% 0;
+  background: var(--theme-foreground);
+  color: var(--theme-background);
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  pointer-events: none;
+  z-index: 9999;
+  animation: copy-toast-fade 1.4s ease forwards;
+}
+
+@keyframes copy-toast-fade {
+  0%   { opacity: 0; translate: -50% 4px; }
+  15%  { opacity: 1; translate: -50% 0; }
+  70%  { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 .cluster-modal-qual {
@@ -847,6 +922,10 @@ label {
     margin-top: 8px;
   }
 
+  .region-card-wrapper {
+    margin-bottom: 1rem;
+  }
+
   /* Truncate ranking labels at ~20 chars */
   .ranking-label {
     overflow: hidden;
@@ -889,5 +968,10 @@ label {
   /* Smaller select inputs inside choropleth selectors */
   .choropleth-selector select {
     font-size: 0.78rem;
+  }
+
+  /* Remove Observable default margins on Inputs.select inside choropleth selectors */
+  .choropleth-selector form[class^="inputs-"] {
+    margin: 0;
   }
 }

--- a/src/eina.md
+++ b/src/eina.md
@@ -18,6 +18,8 @@ import { getEmissionsIndicatorData, getIncomeIndicatorData, getEmissionsData } f
 import { getHoveredInfo, getTickColor, lowercaseFirstLetter, getRegionCardData } from './components/mapHelpers.js';
 import { qualifColorScheme, emissionsColorScheme } from './components/colors.js';
 
+const REGION_CARD_TABLE_ROWS = 5;
+
 const municipisDict = FileAttachment('./data/municipisDict.json').json();
 const pointsData = await FileAttachment('./data/certificats-points.parquet').parquet();
 
@@ -591,7 +593,10 @@ function updateAnalysisZone() {
   if (!topCard || !mapLoaded) return;
   const r = topCard.getBoundingClientRect();
   const vw = window.innerWidth, vh = window.innerHeight;
-  const top = r.bottom + 16, left = 46, right = vw - 46, bottom = vh - 46;
+  const sidebarEl = document.getElementById('observablehq-sidebar');
+  const sidebarRight = sidebarEl ? Math.max(0, sidebarEl.getBoundingClientRect().right) : 0;
+  const left = Math.max(sidebarRight + 8, 46);
+  const top = r.bottom + 16, right = vw - 46, bottom = vh - 46;
   Object.assign(analysisZoneEl.style, {
     top: `${top}px`, left: `${left}px`,
     width: `${right - left}px`, height: `${bottom - top}px`
@@ -600,6 +605,8 @@ function updateAnalysisZone() {
 }
 
 window.addEventListener('resize', updateAnalysisZone);
+document.getElementById('observablehq-sidebar-toggle')
+  ?.addEventListener('change', () => requestAnimationFrame(updateAnalysisZone));
 ```
 
 ${hoveredPolygonId && !isMouseOverUI && !isMouseButtonPressed && mapMode === 'choropleth' ? mapTooltip() : ''}
@@ -808,13 +815,13 @@ const mapTooltip = () => {
       <div class="mb-tip-row">
         <span>${emissionsIndicator.name}</span>
         <span>
-          ${hoveredInfo.emissionsData.value == null ? "—" : fmt(hoveredInfo.emissionsData.value)}
+          ${hoveredInfo.emissionsData.value == null ? "—" : `${fmt(hoveredInfo.emissionsData.value)} ${emissionsIndicator.units}`}
         </span>
       </div>
       <div class="mb-tip-row">
         <span>${incomeIndicator.name}</span>
         <span>
-          ${hoveredInfo.incomeData.value == null ? "—" : fmt(hoveredInfo.incomeData.value)}
+          ${hoveredInfo.incomeData.value == null ? "—" : `${fmt(hoveredInfo.incomeData.value)} ${incomeIndicator.units}`}
         </span>
       </div>
     </div>`;
@@ -951,7 +958,7 @@ const regionCard = () => {
               unitat: '20%'
             },
             layout: 'auto',
-            rows: window.innerWidth < 600 ? 2 : 7
+            rows: window.innerWidth < 600 ? 2 : REGION_CARD_TABLE_ROWS
           })}
         </div>
       </div>
@@ -962,6 +969,15 @@ const regionCard = () => {
 
 ```js
 const QUAL_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+
+const copyRef = async (ref) => {
+  await navigator.clipboard.writeText(ref);
+  const toast = document.createElement('div');
+  toast.className = 'copy-toast';
+  toast.textContent = 'Codi copiat';
+  document.body.appendChild(toast);
+  toast.addEventListener('animationend', () => toast.remove());
+};
 
 const clusterModal = () => {
   const { refs, vals, indicator } = clusterModalData;
@@ -980,7 +996,7 @@ const clusterModal = () => {
         <ul class="cluster-modal-list">
           ${refs.map((ref, i) => html`
             <li>
-              <span class="cluster-modal-ref">${ref}</span>
+              <button class="cluster-modal-ref" onclick=${() => copyRef(ref)} title="Copia la referència cadastral">${ref}</button>
               ${indicator.type === 'qual'
                 ? html`<span class="cluster-modal-qual qual-${vals[i]}">${QUAL_LABELS[vals[i] - 1] ?? '—'}</span>`
                 : html`<span class="cluster-modal-value">${vals[i] != null ? fmt(vals[i]) : '—'} <small>${indicator.units}</small></span>`


### PR DESCRIPTION
## Summary

- Fix sidebar toggle strip visibility and close button positioning (both `eina.css` and `dashboard.css`)
- Pin eina sidebar to 200px width; adjust close button offset to match
- Analysis zone now respects sidebar bounds when toggled open/closed
- Cluster modal cadastral refs are now copyable buttons with a toast confirmation
- Tooltip values now include units; fixed tooltip width with `white-space: nowrap`
- Extract `REGION_CARD_TABLE_ROWS` constant; add bottom margin to region cards
- Remove Observable default margins on `Inputs.select` inside choropleth selectors on mobile

## Test plan

- [ ] Toggle sidebar open/closed in eina — close button should be centred and visible only when open
- [ ] Drag the sidebar toggle strip — should show a subtle strip when collapsed
- [ ] Hover over polygons — tooltip should show values with units and not overflow
- [ ] Open a cluster modal — click a cadastral ref to copy it, toast should appear and dismiss
- [ ] Check analysis zone repositions correctly when sidebar opens/closes
- [ ] Check choropleth selector dropdowns on mobile (≤800px) have no extra margin

🤖 Generated with [Claude Code](https://claude.com/claude-code)